### PR TITLE
Fix for case insensitive note type names

### DIFF
--- a/code/japanese/notetypes.py
+++ b/code/japanese/notetypes.py
@@ -11,11 +11,11 @@ Support plugin here
 from aqt import mw
 
 config = mw.addonManager.getConfig(__name__)
-
+noteTypes = [noteType.lower() for noteType in config["noteTypes"]]
 
 def isJapaneseNoteType(noteName):
     noteName = noteName.lower()
-    for allowedString in config["noteTypes"]:
+    for allowedString in noteTypes:
         if allowedString in noteName:
             return True
 


### PR DESCRIPTION
I noticed that in (what I presume is my old code from the header!) in the `isJapaneseNoteType` function, there was a bug related to case sensitivity. 

My notes use upper and lower cases in their names and I copied their names into the new config settings. Yet no kanji were picked up by the kanji stats. This fixes the issue by using `lower` on the noteTypes config setting when checking the type names.

So essentially, both the actual note type names and the configured names are lowered.