### PR TITLE
refactor: remove obsolete object superclass

### DIFF
--- a/code/cardstats/__init__.py
+++ b/code/cardstats/__init__.py
@@ -23,7 +23,7 @@ class DockableWithClose(QDockWidget):
         QDockWidget.closeEvent(self, evt)
 
 
-class CardStats(object):
+class CardStats:
     def __init__(self, mw: AnkiQt):
         self.mw = mw
         self.shown: DockableWithClose | None = None

--- a/code/japanese/lookup.py
+++ b/code/japanese/lookup.py
@@ -17,7 +17,7 @@ from aqt.utils import showInfo
 setUrl = QUrl.setUrl
 
 
-class Lookup(object):
+class Lookup:
     def __init__(self) -> None:
         pass
 

--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -63,7 +63,7 @@ def mungeForPlatform(popen: list[str]) -> list[str]:
     return popen
 
 
-class MecabController(object):
+class MecabController:
     def __init__(self) -> None:
         self.mecab: subprocess.Popen | None = None
 
@@ -189,7 +189,7 @@ class MecabController(object):
 ##########################################################################
 
 
-class KakasiController(object):
+class KakasiController:
     def __init__(self) -> None:
         self.kakasi: subprocess.Popen | None = None
 

--- a/code/japanese/stats.py
+++ b/code/japanese/stats.py
@@ -29,7 +29,7 @@ def isKanji(unichar: str) -> bool:
         return False
 
 
-class KanjiStats(object):
+class KanjiStats:
     def __init__(self, col: Collection, wholeCollection: bool) -> None:
         self.col = col
         if wholeCollection:


### PR DESCRIPTION
This is Python 2 code and not required anymore since Python 3.0.