### PR TITLE
refactor: remove obsolete encoding pragma

### DIFF
--- a/code/altgrfix/__init__.py
+++ b/code/altgrfix/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 
 from typing import Any

--- a/code/cardstats/__init__.py
+++ b/code/cardstats/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/changecreationtimes/__init__.py
+++ b/code/changecreationtimes/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Matthew Duggan, mostly copied from bulk reading generator plugin
 #            by Damien Elmes.
 #

--- a/code/fixinvalidhtml/__init__.py
+++ b/code/fixinvalidhtml/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/gtts_player/vendor/gtts/__init__.py
+++ b/code/gtts_player/vendor/gtts/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .version import __version__  # noqa: F401
 from .tts import gTTS, gTTSError
 

--- a/code/gtts_player/vendor/gtts/cli.py
+++ b/code/gtts_player/vendor/gtts/cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gtts import gTTS, gTTSError, __version__
 from gtts.lang import tts_langs, _fallback_deprecated_lang
 import click

--- a/code/gtts_player/vendor/gtts/lang.py
+++ b/code/gtts_player/vendor/gtts/lang.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gtts.langs import _main_langs
 from warnings import warn
 import logging

--- a/code/gtts_player/vendor/gtts/tests/test_cli.py
+++ b/code/gtts_player/vendor/gtts/tests/test_cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 import re
 import os

--- a/code/gtts_player/vendor/gtts/tests/test_lang.py
+++ b/code/gtts_player/vendor/gtts/tests/test_lang.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 from gtts.lang import tts_langs, _extra_langs, _fallback_deprecated_lang
 from gtts.langs import _main_langs

--- a/code/gtts_player/vendor/gtts/tests/test_tts.py
+++ b/code/gtts_player/vendor/gtts/tests/test_tts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import pytest
 from unittest.mock import Mock

--- a/code/gtts_player/vendor/gtts/tests/test_utils.py
+++ b/code/gtts_player/vendor/gtts/tests/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 from gtts.utils import _minimize, _len, _clean_tokens, _translate_url
 

--- a/code/gtts_player/vendor/gtts/tokenizer/__init__.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*
 from .core import (
     RegexBuilder,
     PreProcessorRegex,

--- a/code/gtts_player/vendor/gtts/tokenizer/core.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 
 

--- a/code/gtts_player/vendor/gtts/tokenizer/pre_processors.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/pre_processors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gtts.tokenizer import PreProcessorRegex, PreProcessorSub, symbols
 import re
 

--- a/code/gtts_player/vendor/gtts/tokenizer/symbols.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/symbols.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 ABBREVIATIONS = ["dr", "jr", "mr", "mrs", "ms", "msgr", "prof", "sr", "st"]
 
 SUB_PAIRS = [("Esq.", "Esquire")]

--- a/code/gtts_player/vendor/gtts/tokenizer/tests/test_core.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/tests/test_core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 import re
 from gtts.tokenizer.core import (

--- a/code/gtts_player/vendor/gtts/tokenizer/tests/test_pre_processors.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/tests/test_pre_processors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 from gtts.tokenizer.pre_processors import (
     tone_marks,

--- a/code/gtts_player/vendor/gtts/tokenizer/tests/test_tokenizer_cases.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/tests/test_tokenizer_cases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 from gtts.tokenizer.tokenizer_cases import (
     tone_marks,

--- a/code/gtts_player/vendor/gtts/tokenizer/tokenizer_cases.py
+++ b/code/gtts_player/vendor/gtts/tokenizer/tokenizer_cases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gtts.tokenizer import RegexBuilder, symbols
 
 

--- a/code/gtts_player/vendor/gtts/tts.py
+++ b/code/gtts_player/vendor/gtts/tts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 import json
 import logging

--- a/code/gtts_player/vendor/gtts/utils.py
+++ b/code/gtts_player/vendor/gtts/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gtts.tokenizer.symbols import ALL_PUNC as punc
 from string import whitespace as ws
 import re

--- a/code/japanese/__init__.py
+++ b/code/japanese/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 

--- a/code/japanese/bulkreading.py
+++ b/code/japanese/bulkreading.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/japanese/lookup.py
+++ b/code/japanese/lookup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/japanese/model.py
+++ b/code/japanese/model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/japanese/stats.py
+++ b/code/japanese/stats.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # Used/unused kanji list code originally by 'LaC'
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html

--- a/code/localizemedia/__init__.py
+++ b/code/localizemedia/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/mergechilddecks/__init__.py
+++ b/code/mergechilddecks/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 

--- a/code/print/__init__.py
+++ b/code/print/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/quickcolours/__init__.py
+++ b/code/quickcolours/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #

--- a/code/removehistory/__init__.py
+++ b/code/removehistory/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Damien Elmes (http://help.ankiweb.net)
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 

--- a/demos/av_player/__init__.py
+++ b/demos/av_player/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 


### PR DESCRIPTION
This is necessary only if Python 2 is used.