### PR TITLE
refactor: self-document computation of mismatch index

### DIFF
--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -88,7 +88,7 @@ def get_index_of_first_mismatch_from_right_to_left(kanji, reading) -> int:
 
         >>> kanji = "9876543210"
         >>> reading = "987654x210"
-        >>> get_index_of_first_mismatch_from_left_to_right(kanji, reading)
+        >>> get_index_of_first_mismatch_from_right_to_left(kanji, reading)
     """
     index_of_first_mismatch_from_right_to_left = 0
     for i in range(1, len(kanji)):

--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -65,11 +65,21 @@ def mungeForPlatform(popen: list[str]) -> list[str]:
 def get_index_of_first_mismatch_from_left_to_right(kanji, reading) -> int:
     """Get index of first mismatch between Kanji and reading, from left to right.
 
-    Example:
-        This would return 3.
+    Returns:
+        - The index of the first mismatch if there is one, starting at the left end.
+        - The largest index if the two lists are identical (there's no mismatch).
+
+    Examples:
+        This would return 3 because the leftmost mismatch is at index 3.
 
         >>> kanji = "0123456789"
         >>> reading = "012x456789"
+        >>> get_index_of_first_mismatch_from_left_to_right(kanji, reading)
+
+        This would return 9 (the largest index) because the lists are identical.
+
+        >>> kanji = "0123456789"
+        >>> reading = "0123456789"
         >>> get_index_of_first_mismatch_from_left_to_right(kanji, reading)
     """
     index_of_first_mismatch_from_left_to_right = 0
@@ -83,11 +93,21 @@ def get_index_of_first_mismatch_from_left_to_right(kanji, reading) -> int:
 def get_index_of_first_mismatch_from_right_to_left(kanji, reading) -> int:
     """Get index of first mismatch between Kanji and reading, from right to left.
 
-    Example:
-        This would return 3.
+    Returns:
+        - The index of the first mismatch if there is one, starting at the right end.
+        - The largest index if the two lists are identical (there's no mismatch).
+
+    Examples:
+        This would return 3 because the rightmost mismatch is at index 3.
 
         >>> kanji = "9876543210"
         >>> reading = "987654x210"
+        >>> get_index_of_first_mismatch_from_right_to_left(kanji, reading)
+
+        This would return 9 (the largest index) because the lists are identical.
+
+        >>> kanji = "9876543210"
+        >>> reading = "9876543210"
         >>> get_index_of_first_mismatch_from_right_to_left(kanji, reading)
     """
     index_of_first_mismatch_from_right_to_left = 0

--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -63,7 +63,15 @@ def mungeForPlatform(popen: list[str]) -> list[str]:
 
 
 def get_index_of_first_mismatch_from_left_to_right(kanji, reading) -> int:
-    """Get index of first mismatch between Kanji and reading, from left to right."""
+    """Get index of first mismatch between Kanji and reading, from left to right.
+
+    Example:
+        This would return 3.
+
+        >>> kanji = "0123456789"
+        >>> reading = "012x456789"
+        >>> get_index_of_first_mismatch_from_left_to_right(kanji, reading)
+    """
     index_of_first_mismatch_from_left_to_right = 0
     for i in range(0, len(kanji) - 1):
         if kanji[i] != reading[i]:
@@ -73,7 +81,15 @@ def get_index_of_first_mismatch_from_left_to_right(kanji, reading) -> int:
 
 
 def get_index_of_first_mismatch_from_right_to_left(kanji, reading) -> int:
-    """Get index of first mismatch between Kanji and reading, from right to left."""
+    """Get index of first mismatch between Kanji and reading, from right to left.
+
+    Example:
+        This would return 3.
+
+        >>> kanji = "9876543210"
+        >>> reading = "987654x210"
+        >>> get_index_of_first_mismatch_from_left_to_right(kanji, reading)
+    """
     index_of_first_mismatch_from_right_to_left = 0
     for i in range(1, len(kanji)):
         if kanji[-i] != reading[-i]:

--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -64,48 +64,21 @@ def mungeForPlatform(popen: list[str]) -> list[str]:
 
 def get_index_of_first_mismatch_from_left_to_right(kanji, reading) -> int:
     """Get index of first mismatch between Kanji and reading, from left to right."""
-    largest_index = len(kanji) - 1
-
-    def remove_rightmost_element(elements):
-        return elements[:-1]
-
-    kanji_reading_pairs = zip(
-        remove_rightmost_element(kanji),
-        remove_rightmost_element(reading),
-    )
-
-    index_of_first_mismatch_from_left_to_right = next(
-        (
-            index
-            for index, (kanji, reading) in enumerate(kanji_reading_pairs)
-            if kanji != reading
-        ),
-        largest_index,
-    )
+    index_of_first_mismatch_from_left_to_right = 0
+    for i in range(0, len(kanji) - 1):
+        if kanji[i] != reading[i]:
+            break
+        index_of_first_mismatch_from_left_to_right = i + 1
     return index_of_first_mismatch_from_left_to_right
 
 
 def get_index_of_first_mismatch_from_right_to_left(kanji, reading) -> int:
     """Get index of first mismatch between Kanji and reading, from right to left."""
-    largest_index = len(kanji) - 1
-
-    def get_rightmost_to_secondleftmost(elements):
-        second_element_up_to_last_element = elements[1:]
-        return reversed(second_element_up_to_last_element)
-
-    kanji_reading_pairs = zip(
-        get_rightmost_to_secondleftmost(kanji),
-        get_rightmost_to_secondleftmost(reading),
-    )
-
-    index_of_first_mismatch_from_right_to_left = next(
-        (
-            index
-            for index, (kanji, reading) in enumerate(kanji_reading_pairs)
-            if kanji != reading
-        ),
-        largest_index,
-    )
+    index_of_first_mismatch_from_right_to_left = 0
+    for i in range(1, len(kanji)):
+        if kanji[-i] != reading[-i]:
+            break
+        index_of_first_mismatch_from_right_to_left = i
     return index_of_first_mismatch_from_right_to_left
 
 

--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -62,6 +62,29 @@ def mungeForPlatform(popen: list[str]) -> list[str]:
     return popen
 
 
+def get_index_of_first_mismatch_from_left_to_right(kanji, reading) -> int:
+    """Get index of first mismatch between Kanji and reading, from left to right."""
+    largest_index = len(kanji) - 1
+
+    def remove_rightmost_element(elements):
+        return elements[:-1]
+
+    kanji_reading_pairs = zip(
+        remove_rightmost_element(kanji),
+        remove_rightmost_element(reading),
+    )
+
+    index_of_first_mismatch_from_left_to_right = next(
+        (
+            index
+            for index, (kanji, reading) in enumerate(kanji_reading_pairs)
+            if kanji != reading
+        ),
+        largest_index,
+    )
+    return index_of_first_mismatch_from_left_to_right
+
+
 def get_index_of_first_mismatch_from_right_to_left(kanji, reading) -> int:
     """Get index of first mismatch between Kanji and reading, from right to left."""
     largest_index = len(kanji) - 1
@@ -166,11 +189,7 @@ class MecabController:
                 continue
             # strip matching characters and beginning and end of reading and kanji
             # reading should always be at least as long as the kanji
-            placeL = 0
-            for i in range(0, len(kanji) - 1):
-                if kanji[i] != reading[i]:
-                    break
-                placeL = i + 1
+            placeL = get_index_of_first_mismatch_from_left_to_right(kanji, reading)
             placeR = get_index_of_first_mismatch_from_right_to_left(kanji, reading)
             if placeL == 0:
                 if placeR == 0:

--- a/code/japanese/reading.py
+++ b/code/japanese/reading.py
@@ -62,6 +62,30 @@ def mungeForPlatform(popen: list[str]) -> list[str]:
     return popen
 
 
+def get_index_of_first_mismatch_from_right_to_left(kanji, reading) -> int:
+    """Get index of first mismatch between Kanji and reading, from right to left."""
+    largest_index = len(kanji) - 1
+
+    def get_rightmost_to_secondleftmost(elements):
+        second_element_up_to_last_element = elements[1:]
+        return reversed(second_element_up_to_last_element)
+
+    kanji_reading_pairs = zip(
+        get_rightmost_to_secondleftmost(kanji),
+        get_rightmost_to_secondleftmost(reading),
+    )
+
+    index_of_first_mismatch_from_right_to_left = next(
+        (
+            index
+            for index, (kanji, reading) in enumerate(kanji_reading_pairs)
+            if kanji != reading
+        ),
+        largest_index,
+    )
+    return index_of_first_mismatch_from_right_to_left
+
+
 class MecabController:
     def __init__(self) -> None:
         self.mecab: subprocess.Popen | None = None
@@ -143,15 +167,11 @@ class MecabController:
             # strip matching characters and beginning and end of reading and kanji
             # reading should always be at least as long as the kanji
             placeL = 0
-            placeR = 0
-            for i in range(1, len(kanji)):
-                if kanji[-i] != reading[-i]:
-                    break
-                placeR = i
             for i in range(0, len(kanji) - 1):
                 if kanji[i] != reading[i]:
                     break
                 placeL = i + 1
+            placeR = get_index_of_first_mismatch_from_right_to_left(kanji, reading)
             if placeL == 0:
                 if placeR == 0:
                     out.append(f" {kanji}[{reading}]")


### PR DESCRIPTION
Make the code easier to understand that computes the index of the first mismatch between Kanji zipped with reading.

(Both for when going through the list from left to right, and when going from right to left.)

Encapsulating this code in functions allows for unit testing.